### PR TITLE
CI: update workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo build (debug; default features)
         run: cargo build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
To address [a pending deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), and to remove CI warnings this branch brings the CI improvements that landed on the rustls/rustls repo in https://github.com/rustls/rustls/pull/1214 to this repo.

## CI: configure Dependabot to monitor GitHub actions.
This commit updates the existing .github/dependabot.yml config that monitors Cargo dependencies to also monitor GitHub actions (on a weekly cadence).

## CI: actions/checkout@v2 -> v3.
Does what it says on the tin.

## CI: replace actions-rs w/ dtolnay/rust-toolchain.
This commit replaces the actions-rs/toolchain action with dtolnay/rust-toolchain. The former is [no longer maintained](https://github.com/actions-rs/toolchain/issues/216).