### PR TITLE
upgrade webpki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ ring = "0.16.20"
 rustls-pemfile = "1"
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-webpki = { package = "rustls-webpki", version = "0.101.2" }
+webpki = { package = "rustls-webpki", version = "0.101.4" }
 x509-parser = "0.15.1"
 yasna = "0.5.2"


### PR DESCRIPTION
Upgrading `rustls-webpki` to ensure a vulnerable version isn't used from the [rust advisory](https://rustsec.org/advisories/RUSTSEC-2023-0053.html)