### PR TITLE
add no-std support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! yourself by inspecting and re-running the generation process.
 //!
 
+#![no_std]
 #![forbid(unsafe_code, unstable_features)]
 #![deny(
     trivial_casts,

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -387,6 +387,7 @@ const HEADER: &str = r#"//!
 //! yourself by inspecting and re-running the generation process.
 //!
 
+#![no_std]
 #![forbid(unsafe_code, unstable_features)]
 #![deny(
     trivial_casts,


### PR DESCRIPTION
the crate does not rely on libstd API so it's already no-std compatible. it only needs the `#![no_std]` attribute.