### PR TITLE
process upstream February root updates

### DIFF
--- a/webpki-roots/Cargo.toml
+++ b/webpki-roots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.26.0"
+version = "0.26.1"
 edition = { workspace = true }
 readme = "README.md"
 license = "MPL-2.0"

--- a/webpki-roots/src/lib.rs
+++ b/webpki-roots/src/lib.rs
@@ -1951,6 +1951,34 @@ pub const TLS_SERVER_ROOTS: &[TrustAnchor] = &[
   },
 
   /*
+   * Issuer: CN=Telekom Security TLS ECC Root 2020 O=Deutsche Telekom Security GmbH
+   * Subject: CN=Telekom Security TLS ECC Root 2020 O=Deutsche Telekom Security GmbH
+   * Label: "Telekom Security TLS ECC Root 2020"
+   * Serial: 72082518505882327255703894282316633856
+   * SHA256 Fingerprint: 57:8a:f4:de:d0:85:3f:4e:59:98:db:4a:ea:f9:cb:ea:8d:94:5f:60:b6:20:a3:8d:1a:3c:13:b2:bc:7b:a8:e1
+   * -----BEGIN CERTIFICATE-----
+   * MIICQjCCAcmgAwIBAgIQNjqWjMlcsljN0AFdxeVXADAKBggqhkjOPQQDAzBjMQsw
+   * CQYDVQQGEwJERTEnMCUGA1UECgweRGV1dHNjaGUgVGVsZWtvbSBTZWN1cml0eSBH
+   * bWJIMSswKQYDVQQDDCJUZWxla29tIFNlY3VyaXR5IFRMUyBFQ0MgUm9vdCAyMDIw
+   * MB4XDTIwMDgyNTA3NDgyMFoXDTQ1MDgyNTIzNTk1OVowYzELMAkGA1UEBhMCREUx
+   * JzAlBgNVBAoMHkRldXRzY2hlIFRlbGVrb20gU2VjdXJpdHkgR21iSDErMCkGA1UE
+   * AwwiVGVsZWtvbSBTZWN1cml0eSBUTFMgRUNDIFJvb3QgMjAyMDB2MBAGByqGSM49
+   * AgEGBSuBBAAiA2IABM6//leov9Wq9xCazbzREaK9Z0LMkOsVGJDZos0MKiXrPk/O
+   * tdKPD/M12kOLAoC+b1EkHQ9rK8qfwm9QMuU3ILYg/4gND21Ju9sGpIeQkpT0CdDP
+   * f8iAC8GXs7s1J8nCG6NCMEAwHQYDVR0OBBYEFONyzG6VmUex5rNhTNHLq+O6zd6f
+   * MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2cA
+   * MGQCMHVSi7ekEE+uShCLsoRbQuHmKjYC2qBuGT8lv9pZMo7k+5Dck2TOrbRBR2Di
+   * z6fLHgIwN0GMZt9Ba9aDAEH9L1r3ULRn0SyocddDypwnJJGDSA3PzfdUga/sf+Rn
+   * 27iQ7t0l
+   * -----END CERTIFICATE-----
+   */
+  TrustAnchor {
+    subject: Der::from_slice(b"1\x0b0\t\x06\x03U\x04\x06\x13\x02DE1\'0%\x06\x03U\x04\n\x0c\x1eDeutsche Telekom Security GmbH1+0)\x06\x03U\x04\x03\x0c\"Telekom Security TLS ECC Root 2020"),
+    subject_public_key_info: Der::from_slice(b"0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81\x04\x00\"\x03b\x00\x04\xce\xbf\xfeW\xa8\xbf\xd5\xaa\xf7\x10\x9a\xcd\xbc\xd1\x11\xa2\xbdgB\xcc\x90\xeb\x15\x18\x90\xd9\xa2\xcd\x0c*%\xeb>O\xce\xb5\xd2\x8f\x0f\xf35\xdaC\x8b\x02\x80\xbeoQ$\x1d\x0fk+\xca\x9f\xc2oP2\xe57 \xb6 \xff\x88\r\x0fmI\xbb\xdb\x06\xa4\x87\x90\x92\x94\xf4\t\xd0\xcf\x7f\xc8\x80\x0b\xc1\x97\xb3\xbb5\'\xc9\xc2\x1b"),
+    name_constraints: None
+  },
+
+  /*
    * Issuer: CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
    * Subject: CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
    * Label: "Autoridad de Certificacion Firmaprofesional CIF A62634068"
@@ -4936,39 +4964,6 @@ pub const TLS_SERVER_ROOTS: &[TrustAnchor] = &[
   },
 
   /*
-   * Issuer: O=SECOM Trust.net OU=Security Communication RootCA1
-   * Subject: O=SECOM Trust.net OU=Security Communication RootCA1
-   * Label: "SECOM Trust.net - Security Communication RootCA1"
-   * Serial: 0
-   * SHA256 Fingerprint: e7:5e:72:ed:9f:56:0e:ec:6e:b4:80:00:73:a4:3f:c3:ad:19:19:5a:39:22:82:01:78:95:97:4a:99:02:6b:6c
-   * -----BEGIN CERTIFICATE-----
-   * MIIDWjCCAkKgAwIBAgIBADANBgkqhkiG9w0BAQUFADBQMQswCQYDVQQGEwJKUDEY
-   * MBYGA1UEChMPU0VDT00gVHJ1c3QubmV0MScwJQYDVQQLEx5TZWN1cml0eSBDb21t
-   * dW5pY2F0aW9uIFJvb3RDQTEwHhcNMDMwOTMwMDQyMDQ5WhcNMjMwOTMwMDQyMDQ5
-   * WjBQMQswCQYDVQQGEwJKUDEYMBYGA1UEChMPU0VDT00gVHJ1c3QubmV0MScwJQYD
-   * VQQLEx5TZWN1cml0eSBDb21tdW5pY2F0aW9uIFJvb3RDQTEwggEiMA0GCSqGSIb3
-   * DQEBAQUAA4IBDwAwggEKAoIBAQCzs/5/022x7xZ8V6UMbXaKL0u/ZPtM7orw8yl8
-   * 9f/uKuDp6bpbZCKamm8sOiZpUQWZJtzVHGpxxpp9Hp3dfGzGjGdnSj74cbAZJ6kJ
-   * DKaVv0uMDPpVmDvY6CKhS3E4eayXkmmziX7qIWgGmBSWh9JhNrxtJ1aeV+7AwFb9
-   * Ms+k2Y7CI9eNqPPYJayX5HA49LY6tJ07lyZDo6G8SVlyTCMwhwFY9k6+HGhWZq/N
-   * QV3Is00qVUarH9oe4kA92819uZKAnDfdDJZkndwi92SL32HeFZRSFaB9UslLqCHJ
-   * xrHty8OVYNEP8Ktw+N/LTX7s1vqr2b1/VPKl6Xn62dZ2JChzAgMBAAGjPzA9MB0G
-   * A1UdDgQWBBSgc0mZaNyFW2XjmygvV5+9M7wHSDALBgNVHQ8EBAMCAQYwDwYDVR0T
-   * AQH/BAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEAaECpqLvkT115swW1F7NgE+vG
-   * kl3g0dNq/vu+m22/xwVtWSDEHPC32oRYAmP6SBbvT6UL90qY8j+eG61Ha2POCEfr
-   * Uj94nK9NrvjVT8+amCoQQTlSxN3Zmw7vkwGusi7KaEIkQmywszo+zenaSMQVy+n5
-   * Bw+SUEmK3TGXX8npN6o7WWWXlDLJs58+OmJYxUmtYg5xpTKqL8aJdkNAExNnPaJU
-   * JRDL8Try2frbSVa7pv6nQTXD4IhhyYjH3zYQIphZ6rBK+1YWc26sTfcioU+tHXot
-   * RSflMMFe8toTyyVCUZVHA4xsIcx0Qu1T/zOLjw9XARYvz6buyXAiFL39vmwLAw==
-   * -----END CERTIFICATE-----
-   */
-  TrustAnchor {
-    subject: Der::from_slice(b"1\x0b0\t\x06\x03U\x04\x06\x13\x02JP1\x180\x16\x06\x03U\x04\n\x13\x0fSECOM Trust.net1\'0%\x06\x03U\x04\x0b\x13\x1eSecurity Communication RootCA1"),
-    subject_public_key_info: Der::from_slice(b"0\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00\x03\x82\x01\x0f\x000\x82\x01\n\x02\x82\x01\x01\x00\xb3\xb3\xfe\x7f\xd3m\xb1\xef\x16|W\xa5\x0cmv\x8a/K\xbfd\xfbL\xee\x8a\xf0\xf3)|\xf5\xff\xee*\xe0\xe9\xe9\xba[d\"\x9a\x9ao,:&iQ\x05\x99&\xdc\xd5\x1cjq\xc6\x9a}\x1e\x9d\xdd|l\xc6\x8cggJ>\xf8q\xb0\x19\'\xa9\t\x0c\xa6\x95\xbfK\x8c\x0c\xfaU\x98;\xd8\xe8\"\xa1Kq8y\xac\x97\x92i\xb3\x89~\xea!h\x06\x98\x14\x96\x87\xd2a6\xbcm\'V\x9eW\xee\xc0\xc0V\xfd2\xcf\xa4\xd9\x8e\xc2#\xd7\x8d\xa8\xf3\xd8%\xac\x97\xe4p8\xf4\xb6:\xb4\x9d;\x97&C\xa3\xa1\xbcIYrL#0\x87\x01X\xf6N\xbe\x1chVf\xaf\xcdA]\xc8\xb3M*UF\xab\x1f\xda\x1e\xe2@=\xdb\xcd}\xb9\x92\x80\x9c7\xdd\x0c\x96d\x9d\xdc\"\xf7d\x8b\xdfa\xde\x15\x94R\x15\xa0}R\xc9K\xa8!\xc9\xc6\xb1\xed\xcb\xc3\x95`\xd1\x0f\xf0\xabp\xf8\xdf\xcbM~\xec\xd6\xfa\xab\xd9\xbd\x7fT\xf2\xa5\xe9y\xfa\xd9\xd6v$(s\x02\x03\x01\x00\x01"),
-    name_constraints: None
-  },
-
-  /*
    * Issuer: CN=USERTrust RSA Certification Authority O=The USERTRUST Network
    * Subject: CN=USERTrust RSA Certification Authority O=The USERTRUST Network
    * Label: "USERTrust RSA Certification Authority"
@@ -5206,6 +5201,52 @@ pub const TLS_SERVER_ROOTS: &[TrustAnchor] = &[
   TrustAnchor {
     subject: Der::from_slice(b"1\x0b0\t\x06\x03U\x04\x06\x13\x02DE1\x150\x13\x06\x03U\x04\n\x0c\x0cD-Trust GmbH1*0(\x06\x03U\x04\x03\x0c!D-TRUST Root Class 3 CA 2 EV 2009"),
     subject_public_key_info: Der::from_slice(b"0\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00\x03\x82\x01\x0f\x000\x82\x01\n\x02\x82\x01\x01\x00\x99\xf1\x844p\xba/\xb70\xa0\x8e\xbd|\x04\xcf\xbeb\xbc\x99\xfd\x82\x97\xd2z\ng\x968\t\xf6\x10N\x95\"s\x99\x8d\xda\x15-\xe7\x05\xfc\x19s\"\xb7\x8e\x98\x00\xbc<=\xac\xa1l\xfb\xd6y%K\xad\xf0\xccd\xda\x88>)\xb8\x0f\t\xd34\xdd3\xf5b\xd1\xe1\xcd\x19\xe9\xee\x18OLX\xae\xe2\x1e\xd6\x0c[\x15Z\xd8:\xb8\xc4\x18d\x1e\xe33\xb2\xb5\x89wN\x0c\xbf\xd9\x94k\x13\x97o\x12\xa3\xfe\x99\xa9\x04\xcc\x15\xec`h6\xed\x08{\xb7\xf5\xbf\x93\xedf1\x83\x8c\xc6q4\x87N\x17\xea\xaf\x8b\x91\x8d\x1cVA\xae\"7^7\xf2\x1d\xd9\xd1-\r/iQ\xa7\xbef\xa6\x8a:*\xbd\xc7\x1a\xb1\xe1\x14\xf0\xbe:\x1d\xb9\xcf[\xb1j\xfe\xb4\xb1F \xa2\xfb\x1e;p\xef\x93\x98}\x8cs\x96\xf2\xc5\xef\x85p\xad)&\xfc\x1e\x04>\x1c\xa0\xd8\x0f\xcbR\x83b|\xee\x8bS\x95\x90\xa9W\xa2\xeaa\x05\xd8\xf9M\xc4\'\xfan\xad\xed\xf9\xd7Q\xf7k\xa5\x02\x03\x01\x00\x01"),
+    name_constraints: None
+  },
+
+  /*
+   * Issuer: CN=Telekom Security TLS RSA Root 2023 O=Deutsche Telekom Security GmbH
+   * Subject: CN=Telekom Security TLS RSA Root 2023 O=Deutsche Telekom Security GmbH
+   * Label: "Telekom Security TLS RSA Root 2023"
+   * Serial: 44676229530606711399881795178081572759
+   * SHA256 Fingerprint: ef:c6:5c:ad:bb:59:ad:b6:ef:e8:4d:a2:23:11:b3:56:24:b7:1b:3b:1e:a0:da:8b:66:55:17:4e:c8:97:86:46
+   * -----BEGIN CERTIFICATE-----
+   * MIIFszCCA5ugAwIBAgIQIZxULej27HF3+k7ow3BXlzANBgkqhkiG9w0BAQwFADBj
+   * MQswCQYDVQQGEwJERTEnMCUGA1UECgweRGV1dHNjaGUgVGVsZWtvbSBTZWN1cml0
+   * eSBHbWJIMSswKQYDVQQDDCJUZWxla29tIFNlY3VyaXR5IFRMUyBSU0EgUm9vdCAy
+   * MDIzMB4XDTIzMDMyODEyMTY0NVoXDTQ4MDMyNzIzNTk1OVowYzELMAkGA1UEBhMC
+   * REUxJzAlBgNVBAoMHkRldXRzY2hlIFRlbGVrb20gU2VjdXJpdHkgR21iSDErMCkG
+   * A1UEAwwiVGVsZWtvbSBTZWN1cml0eSBUTFMgUlNBIFJvb3QgMjAyMzCCAiIwDQYJ
+   * KoZIhvcNAQEBBQADggIPADCCAgoCggIBAO01oYGA88tKaVvC+1GDrib94W7zgRJ9
+   * cUD/h3VCKSHtgVIs3xLBGYSJwb3FKNXVS2xE1kzbB5ZKVXrKNoIENqil/Cf2SfHV
+   * cp6R+SPWcHu79ZvB7JPPGeplfohwoHP89v+1VmLhc2o0mD6CuKyVU/QBoCcHcqMA
+   * U6DksquDOFczJZSfvkgdmOGjup5czQRxUX11eKvzWarE4GC+j4NSuHUaQTXtvPM6
+   * Y+mpFEXX5lLRbtLevOP1Czvm4MS9Q2QTps70mDdsipWol8hHD/BeEIvnHRz+sTug
+   * BTNoBUGCwQMrAcjnj02r6LX2zWtEtefdi+zqJbQAIldNsLGyMcEWzv/9FIS3R/qy
+   * 8XDe24tsNlikfLMR0cN3f1+2JeANxdKz+bi4d9s3cXFH42AYTyS2dTd4uaNir73J
+   * co4vzLuu2+QVUhkHM/tqty1LkCiCc/4YizWN26cEar7qwU02OxY2kTLvtkCJkUPg
+   * 8qKrBC7m8kwOFjQgrIfBLX7JZkcXFBGk8/ehJImr2BrIoVyxo/eMbcgByU/J7MT8
+   * rFEz0ciD0cmfHdRHNCk+y7AO+oMLKFjlKdw/fKifybYKu6boRhYPluV75Gp6SG12
+   * mAWl3G0eQh5C2hrgUve1g8Aae3g1LDj1H/1Joy7SWWO/gLCMk3PLNaaZlSJhZQNg
+   * +y+TS/qanIA7AgMBAAGjYzBhMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUtqeX
+   * gj10hZv3PJ+TmpV5dVKMbUcwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBS2
+   * p5eCPXSFm/c8n5OalXl1UoxtRzANBgkqhkiG9w0BAQwFAAOCAgEAqMxhpr51nhVQ
+   * pGv7qHBFfLp+sVr8WyP6Cnf4mHGCDG3gXkaqk/QeoMPhk9tLrbKmXauw1GLLXrtm
+   * 9S3ul0A8Yute1hTWjOKWi0FpkzXmuZlrYrShF2Y0pmtjxrlO8iLpWA1WQdH6DErw
+   * M807u20hOq6OcrXDSvvpfeWxm4bu4uB9tPcy/SKE8YXJN3nptT+/XOR0so8RYgDd
+   * GGah2XsjX/GO1WfoVNpbOms2b/mBsTNHM3dA+VKq3dSDz4V4mZqTuXNnQkYRIer+
+   * CqkbGmVps4+uFrb2S1ayLfmlyOw7YqPta9BO1UAJpB+Y1zqlklkg5LB9zVtzaL1t
+   * xKITDmcZuI1CfmwMmm6gJC3VRRvcxAIU/oVbZZfKTpBQCHpCNfnqwmbU+AGuHrS+
+   * w6jv/naaoqYfRvaE7fzbzsQCzndILIyy7MMAo+wsVRjBfhnu4S/yrYObnqsZ38aK
+   * L4x35bcF7DvB7L6Gs4a8wPfc5+pbrrLMtTWGS9DiP7bY+A4A7l3j941Y/8+LN+lj
+   * X273CXE2whJdV/LItM3z7gLfEdxquVeEHVlNjM7IDiPCtyaaEBRx/pOyiriA8A4Q
+   * ntOoUAw3gi/q4Iqd4Sw5/7W0cwDk90imc6y/st53BIe0o82bNSQ3+pCTE4FCxpgm
+   * dTdmQRCsu/WU48IxK63nI1bMNSWSs1A=
+   * -----END CERTIFICATE-----
+   */
+  TrustAnchor {
+    subject: Der::from_slice(b"1\x0b0\t\x06\x03U\x04\x06\x13\x02DE1\'0%\x06\x03U\x04\n\x0c\x1eDeutsche Telekom Security GmbH1+0)\x06\x03U\x04\x03\x0c\"Telekom Security TLS RSA Root 2023"),
+    subject_public_key_info: Der::from_slice(b"0\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00\x03\x82\x02\x0f\x000\x82\x02\n\x02\x82\x02\x01\x00\xed5\xa1\x81\x80\xf3\xcbJi[\xc2\xfbQ\x83\xae&\xfd\xe1n\xf3\x81\x12}q@\xff\x87uB)!\xed\x81R,\xdf\x12\xc1\x19\x84\x89\xc1\xbd\xc5(\xd5\xd5KlD\xd6L\xdb\x07\x96JUz\xca6\x82\x046\xa8\xa5\xfc\'\xf6I\xf1\xd5r\x9e\x91\xf9#\xd6p{\xbb\xf5\x9b\xc1\xec\x93\xcf\x19\xeae~\x88p\xa0s\xfc\xf6\xff\xb5Vb\xe1sj4\x98>\x82\xb8\xac\x95S\xf4\x01\xa0\'\x07r\xa3\x00S\xa0\xe4\xb2\xab\x838W3%\x94\x9f\xbeH\x1d\x98\xe1\xa3\xba\x9e\\\xcd\x04qQ}ux\xab\xf3Y\xaa\xc4\xe0`\xbe\x8f\x83R\xb8u\x1aA5\xed\xbc\xf3:c\xe9\xa9\x14E\xd7\xe6R\xd1n\xd2\xde\xbc\xe3\xf5\x0b;\xe6\xe0\xc4\xbdCd\x13\xa6\xce\xf4\x987l\x8a\x95\xa8\x97\xc8G\x0f\xf0^\x10\x8b\xe7\x1d\x1c\xfe\xb1;\xa0\x053h\x05A\x82\xc1\x03+\x01\xc8\xe7\x8fM\xab\xe8\xb5\xf6\xcdkD\xb5\xe7\xdd\x8b\xec\xea%\xb4\x00\"WM\xb0\xb1\xb21\xc1\x16\xce\xff\xfd\x14\x84\xb7G\xfa\xb2\xf1p\xde\xdb\x8bl6X\xa4|\xb3\x11\xd1\xc3w\x7f_\xb6%\xe0\r\xc5\xd2\xb3\xf9\xb8\xb8w\xdb7qqG\xe3`\x18O$\xb6u7x\xb9\xa3b\xaf\xbd\xc9r\x8e/\xcc\xbb\xae\xdb\xe4\x15R\x19\x073\xfbj\xb7-K\x90(\x82s\xfe\x18\x8b5\x8d\xdb\xa7\x04j\xbe\xea\xc1M6;\x166\x912\xef\xb6@\x89\x91C\xe0\xf2\xa2\xab\x04.\xe6\xf2L\x0e\x164 \xac\x87\xc1-~\xc9fG\x17\x14\x11\xa4\xf3\xf7\xa1$\x89\xab\xd8\x1a\xc8\xa1\\\xb1\xa3\xf7\x8cm\xc8\x01\xc9O\xc9\xec\xc4\xfc\xacQ3\xd1\xc8\x83\xd1\xc9\x9f\x1d\xd4G4)>\xcb\xb0\x0e\xfa\x83\x0b(X\xe5)\xdc?|\xa8\x9f\xc9\xb6\n\xbb\xa6\xe8F\x16\x0f\x96\xe5{\xe4jzHmv\x98\x05\xa5\xdcm\x1eB\x1eB\xda\x1a\xe0R\xf7\xb5\x83\xc0\x1a{x5,8\xf5\x1f\xfdI\xa3.\xd2Yc\xbf\x80\xb0\x8c\x93s\xcb5\xa6\x99\x95\"ae\x03`\xfb/\x93K\xfa\x9a\x9c\x80;\x02\x03\x01\x00\x01"),
     name_constraints: None
   },
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1870673

Removals:

1. SECOM Trust.net - Security Communication RootCA1

   This expired root CA was removed upstream.
   See https://bugzilla.mozilla.org/show_bug.cgi?id=1865450

Additions:

1. Telekom Security TLS ECC Root 2020
   See https://bugzilla.mozilla.org/show_bug.cgi?id=1820592

2. Telekom Security TLS RSA Root 2023
   See https://bugzilla.mozilla.org/show_bug.cgi?id=1820592