### PR TITLE
Small documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ The webpki-ccadb crate populates the root certificates for the webpki-roots crat
 using the data provided by the [Common CA Database (CCADB)](https://www.ccadb.org/).
 Inspired by [certifi.io](https://certifi.io/en/latest/).
 
-The webpki-roots crate is inspired by [certifi.io](https://certifi.io/en/latest/) and
-uses the data provided by the [Common CA Database (CCADB)](https://www.ccadb.org/).
-
 [![webpki-roots](https://github.com/rustls/webpki-roots/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/rustls/webpki-roots/actions/workflows/build.yml)
 [![Crate](https://img.shields.io/crates/v/webpki-roots.svg)](https://crates.io/crates/webpki-roots)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Inspired by [certifi.io](https://certifi.io/en/latest/).
 [![webpki-roots](https://github.com/rustls/webpki-roots/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/rustls/webpki-roots/actions/workflows/build.yml)
 [![Crate](https://img.shields.io/crates/v/webpki-roots.svg)](https://crates.io/crates/webpki-roots)
 
+# Warning
+
+This library is suitable for use in applications that can always be recompiled and instantly deployed.
+For applications that are deployed to end-users and cannot be recompiled, or which need certification
+before deployment, consider a library that uses the platform native certificate verifier such as
+[rustls-platform-verifier]. This has the additional benefit of supporting OS provided CA constraints
+and revocation data.
+
+[rustls-platform-verifier]: https://docs.rs/rustls-platform-verifier
+
 # License
 The underlying data is MPL-licensed, and `webpki-roots/src/lib.rs`
 is therefore a derived work.

--- a/webpki-roots/src/lib.rs
+++ b/webpki-roots/src/lib.rs
@@ -10,8 +10,11 @@
 //!
 //! This library is suitable for use in applications that can always be recompiled and instantly deployed.
 //! For applications that are deployed to end-users and cannot be recompiled, or which need certification
-//! before deployment, consider a library that loads certificates at runtime, like
-//! [rustls-native-certs](https://docs.rs/rustls-native-certs).
+//! before deployment, consider a library that uses the platform native certificate verifier such as
+//! [rustls-platform-verifier]. This has the additional benefit of supporting OS provided CA constraints
+//! and revocation data.
+//!
+//! [rustls-platform-verifier]: https://docs.rs/rustls-platform-verifier
 //
 // This library is automatically generated from the Mozilla
 // IncludedCACertificateReportPEMCSV report via ccadb.org. Don't edit it.

--- a/webpki-roots/tests/codegen.rs
+++ b/webpki-roots/tests/codegen.rs
@@ -147,8 +147,11 @@ const HEADER: &str = r#"//! A compiled-in copy of the root certificates trusted 
 //!
 //! This library is suitable for use in applications that can always be recompiled and instantly deployed.
 //! For applications that are deployed to end-users and cannot be recompiled, or which need certification
-//! before deployment, consider a library that loads certificates at runtime, like
-//! [rustls-native-certs](https://docs.rs/rustls-native-certs).
+//! before deployment, consider a library that uses the platform native certificate verifier such as
+//! [rustls-platform-verifier]. This has the additional benefit of supporting OS provided CA constraints
+//! and revocation data.
+//!
+//! [rustls-platform-verifier]: https://docs.rs/rustls-platform-verifier
 //
 // This library is automatically generated from the Mozilla
 // IncludedCACertificateReportPEMCSV report via ccadb.org. Don't edit it.


### PR DESCRIPTION
* Remove some duplicated content from the top-level README
* Update the webpki-roots rustdoc to recommend rustls-platform-verifier instead of rustls-native-certs
* Port the recommendation/warning from rustdoc to the top-level README