### PR TITLE
webpki-root-certs 0.26.4 release

### DIFF
--- a/webpki-root-certs/Cargo.toml
+++ b/webpki-root-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-root-certs"
-version = "0.26.3"
+version = "0.26.4"
 edition.workspace = true
 readme = "README.md"
 license = "MPL-2.0"

--- a/webpki-roots/Cargo.toml
+++ b/webpki-roots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.26.3"
+version = "0.26.4-not-released"
 edition = { workspace = true }
 readme = "README.md"
 license = "MPL-2.0"


### PR DESCRIPTION
Since the 0.26.3 release has already been tagged before the `webpki-roots-crate` existed I think it makes sense to bump the version for the first `webpki-roots-crate` release. We will not publish the `webpki-roots` 0.26.4 release since it's identical to 0.26.3.

## Proposed release notes

* New `webpki-root-certs` crate. This crate is similar to `webpki-roots`, but for use with other projects that require the full self-signed X.509 certificate for each trusted root. This is unnecessary overhead for `webpki` and `rustls` and you should prefer using `webpki-roots` for these projects.