### PR TITLE
webpki-roots/webpki-root-certs: prepare 0.26.6, fix license data

### DIFF
--- a/LICENSE-MPL
+++ b/LICENSE-MPL
@@ -1,0 +1,21 @@
+This packge contains a modified version of ca-bundle.crt:	
+
+ca-bundle.crt -- Bundle of CA Root Certificates	
+
+Certificate data from Mozilla as of: Thu Nov  3 19:04:19 2011#	
+This is a bundle of X.509 certificates of public Certificate Authorities	
+(CA). These were automatically extracted from Mozilla's root certificates	
+file (certdata.txt).  This file can be found in the mozilla source tree:	
+http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1#	
+It contains the certificates in PEM format and therefore	
+can be directly used with curl / libcurl / php_curl, or with	
+an Apache+mod_ssl webserver for SSL client authentication.	
+Just configure this file as the SSLCACertificateFile.#	
+
+***** BEGIN LICENSE BLOCK *****	
+This Source Code Form is subject to the terms of the Mozilla Public License,	
+v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain	
+one at http://mozilla.org/MPL/2.0/.	
+
+***** END LICENSE BLOCK *****	
+@(#) $RCSfile: certdata.txt,v $ $Revision: 1.80 $ $Date: 2011/11/03 15:11:58 $	

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ and revocation data.
 # License
 
 The underlying data is MPL-licensed, and the data in `webpki-roots` and `webpki-root-certs`
-is therefore a derived work.
+is therefore a derived work. The tooling in `webpki-ccadb` is licensed under
+both MIT and Apache licenses.

--- a/webpki-root-certs/Cargo.toml
+++ b/webpki-root-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-root-certs"
-version = "0.26.5"
+version = "0.26.6"
 edition.workspace = true
 readme = "README.md"
 license = "MPL-2.0"

--- a/webpki-root-certs/LICENSE
+++ b/webpki-root-certs/LICENSE
@@ -1,0 +1,1 @@
+../LICENSE-MPL

--- a/webpki-root-certs/LICENSE-APACHE
+++ b/webpki-root-certs/LICENSE-APACHE
@@ -1,1 +1,0 @@
-../LICENSE-APACHE

--- a/webpki-root-certs/LICENSE-MIT
+++ b/webpki-root-certs/LICENSE-MIT
@@ -1,1 +1,0 @@
-../LICENSE-MIT

--- a/webpki-roots/Cargo.toml
+++ b/webpki-roots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 edition = { workspace = true }
 readme = "README.md"
 license = "MPL-2.0"

--- a/webpki-roots/LICENSE
+++ b/webpki-roots/LICENSE
@@ -1,0 +1,1 @@
+../LICENSE-MPL

--- a/webpki-roots/LICENSE-APACHE
+++ b/webpki-roots/LICENSE-APACHE
@@ -1,1 +1,0 @@
-../LICENSE-APACHE

--- a/webpki-roots/LICENSE-MIT
+++ b/webpki-roots/LICENSE-MIT
@@ -1,1 +1,0 @@
-../LICENSE-MIT


### PR DESCRIPTION
These crates mistakenly had license files included for Apache and MIT licenses. Both are derived works under an MPL 2.0 license

Resolves https://github.com/rustls/webpki-roots/issues/79