### PR TITLE
docs(webpki-roots): simplify usage example

### DIFF
--- a/webpki-roots/src/lib.rs
+++ b/webpki-roots/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```rust
 //! let root_store = rustls::RootCertStore {
-//!   roots: webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect(),
+//!   roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
 //! };
 //! ```
 //!

--- a/webpki-roots/tests/codegen.rs
+++ b/webpki-roots/tests/codegen.rs
@@ -141,7 +141,7 @@ const HEADER: &str = r#"//! A compiled-in copy of the root certificates trusted 
 //!
 //! ```rust
 //! let root_store = rustls::RootCertStore {
-//!   roots: webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect(),
+//!   roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
 //! };
 //! ```
 //!


### PR DESCRIPTION
copy-pasting the main usage example produces a clippy warning suggesting this instead