### PR TITLE
ci: use persist-credentials: false throughout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
We already do this in most of the other Rustls crates, and Zizmor 0.7.0 [flags its absence](https://woodruffw.github.io/zizmor/audits/#artipacked) in this repo. As mentioned in the description of this finding:

> By default, using [actions/checkout](https://github.com/actions/checkout) causes a credential to be persisted in the checked-out repo's .git/config, so that subsequent git operations can be authenticated.
> 
> Subsequent steps may accidentally publicly persist .git/config, e.g. by including it in a publicly accessible artifact via [actions/upload-artifact](https://github.com/actions/upload-artifact).
>
> However, even without this, persisting the credential in the .git/config is non-ideal unless actually needed.

We don't need it, so turn it off :-)