### PR TITLE
Add explicit MPL-2.0 licence notice "Exhibit A"

### DIFF
--- a/webpki-root-certs/Cargo.toml
+++ b/webpki-root-certs/Cargo.toml
@@ -8,6 +8,15 @@ homepage.workspace = true
 repository.workspace = true
 description = "Mozilla trusted certificate authorities in self-signed X.509 format for use with crates other than webpki"
 
+# The following notice applies to all the files in this source subtree:
+#
+#     This Source Code Form is subject to the terms of the Mozilla Public
+#     License, v. 2.0. If a copy of the MPL was not distributed with this
+#     file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# (If you copy files from here into another program which is not
+# licenced MPL-2.0, you should add that notice to each copied file.)
+
 [dependencies]
 pki-types = { workspace = true }
 

--- a/webpki-roots/Cargo.toml
+++ b/webpki-roots/Cargo.toml
@@ -8,6 +8,15 @@ homepage = { workspace = true }
 repository = { workspace = true }
 description = "Mozilla's CA root certificates for use with webpki"
 
+# The following notice applies to all the files in this source subtree:
+#
+#     This Source Code Form is subject to the terms of the Mozilla Public
+#     License, v. 2.0. If a copy of the MPL was not distributed with this
+#     file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# (If you copy files from here into another program which is not
+# licenced MPL-2.0, you should add that notice to each copied file.)
+
 [dependencies]
 pki-types = { workspace = true }
 


### PR DESCRIPTION
Unlike most other Free Software licences, the MPL explicitly says it applies only to files with a specific notice:

    1.4. "Covered Software"
	means Source Code Form to which the initial Contributor has attached
	the notice in Exhibit A, the Executable Form of such Source Code
	Form, and Modifications of such Source Code Form, in each case
	including portions thereof.

Unfortunately, this means that copying the MPL text into tree, and setting the "license" Cargo option, leaves an ambiguous situation. One might presume that the intent was to actually *use* the MPL for the whole project, but the legal licence text explicitly rejects that.

Thankfully, according to the licence text, it is not actually necessary to add the notice to *every* file:

    If it is not possible or desirable to put the notice in a particular
    file, then You may include the notice in a location (such as a LICENSE
    file in a relevant directory) where a recipient would be likely to look
    for such a notice.

So clarify this situation by adding two explicit copies of the MPL "Exhibit A" text, one in each affected crate subtree, and declare them to apply to everything.

Putting these in Cargo.toml puts them next to the "license =" tag. Another possibility would be `README.md` but IMO this legal technicality doesn't really warrant such exposure.

(Putting it in the LICENCE file, as the text itself suggests, would mean either (i) renaming the verbatim copy of the MPL 2.0 and writing a new file or (ii) adding it as a rubric to the top of the MPL 2.0 text in LICENCE - resulting in a LICENCE file which is not identical to the usual MPL-2.0 text file.  Neither of those seem desirable.

Putting just once it at the repository toplevel would mean it didn't appear in .crate files, and also require explicitly stating which subsections of the repository are covered.)

(Commit message text adapted from similar situations in [option-ext](https://github.com/soc/option-ext/pull/4) and [generational-arena](https://github.com/fitzgen/generational-arena/pull/56)