### PR TITLE
Support code-signing trust bit

### DIFF
--- a/webpki-ccadb/src/lib.rs
+++ b/webpki-ccadb/src/lib.rs
@@ -250,6 +250,8 @@ pub enum TrustBits {
     Websites,
     /// certificate is trusted for Email (e.g. S/MIME).
     Email,
+    /// certificate is trusted for code signing
+    Code,
 }
 
 impl From<&str> for TrustBits {
@@ -257,6 +259,7 @@ impl From<&str> for TrustBits {
         match value {
             "Websites" => TrustBits::Websites,
             "Email" => TrustBits::Email,
+            "Code" => TrustBits::Code,
             val => panic!("unknown trust bit: {:?}", val),
         }
     }


### PR DESCRIPTION
See https://github.com/rustls/webpki-roots/actions/runs/13998435097/attempts/1

This has now fixed itself -- https://github.com/rustls/webpki-roots/actions/runs/13998435097/attempts/2 -- so there is no pressing need to land this.