### PR TITLE
Prepare 1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,15 @@ jobs:
 
       - name: cargo test (debug; default features)
         run: cargo test
+
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/webpki-root-certs/Cargo.toml
+++ b/webpki-root-certs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-root-certs"
-version = "0.26.10"
+version = "1.0.0"
 edition.workspace = true
 readme = "README.md"
 license = "CDLA-Permissive-2.0"

--- a/webpki-roots/Cargo.toml
+++ b/webpki-roots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpki-roots"
-version = "0.26.10"
+version = "1.0.0"
 edition = { workspace = true }
 readme = "README.md"
 license = "CDLA-Permissive-2.0"


### PR DESCRIPTION
This PR rubber stamps 0.26.10 as 1.0.0 with no changes.

After we merge this and release it, we can then:

- Branch rel-0.26
- Open a PR for landing https://github.com/rustls/webpki-roots/commit/c98a20d52e7ba6661ea48e1cbb47f379da46a38f or similar there.
- Release 0.26.11.

This would be the final 0.26 release, and AIUI means people continuing to depend on `webpki-roots = "0.26"` will get all future 1.0 releases.