### PR TITLE
Address clippy::non_canonical_partial_ord_impl

### DIFF
--- a/webpki-ccadb/src/lib.rs
+++ b/webpki-ccadb/src/lib.rs
@@ -241,7 +241,7 @@ impl CertificateMetadata {
 
 impl PartialOrd for CertificateMetadata {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.sha256_fingerprint.cmp(&other.sha256_fingerprint))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
```
warning: non-canonical implementation of `partial_cmp` on an `Ord` type
   --> webpki-ccadb/src/lib.rs:242:1
    |
242 | /  impl PartialOrd for CertificateMetadata {
243 | |      fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
    | | _____________________________________________________________-
244 | ||         Some(self.sha256_fingerprint.cmp(&other.sha256_fingerprint))
245 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
246 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_partial_ord_impl
    = note: `#[warn(clippy::non_canonical_partial_ord_impl)]` on by default
```