### PR TITLE
Test MSRV with 1.70

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64.0
+          toolchain: 1.70.0
       - run: cargo check --locked --lib --manifest-path webpki-roots/Cargo.toml
       - run: cargo check --locked --lib --manifest-path webpki-root-certs/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.70"
 homepage = "https://github.com/rustls/webpki-roots"
 repository = "https://github.com/rustls/webpki-roots"
 


### PR DESCRIPTION
1.64 is basically unusable now, as it doesn't support sparse index for cargo.  That means building anything takes ten minutes.

The actual MSRV remains as 1.64.