### PR TITLE
Take webpki-root-certs lockfile update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "windows-sys 0.61.2",
 ]
 
@@ -1601,15 +1601,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-root-certs"
 version = "1.0.8"
 dependencies = [
  "aws-lc-rs",
@@ -1620,6 +1611,15 @@ dependencies = [
  "tokio",
  "webpki-ccadb",
  "x509-parser",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]


### PR DESCRIPTION
Update the locked registry copy of `webpki-root-certs` from 1.0.7 to 1.0.8.

This keeps the lockfile aligned with the current workspace crate release while avoiding a broader dependency refresh that would currently pull in MSRV-incompatible transitive updates.

Testing:
- `cargo build --locked --all-targets`
- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo +1.70.0 check --locked --lib --manifest-path webpki-roots/Cargo.toml`
- `cargo +1.70.0 check --locked --lib --manifest-path webpki-root-certs/Cargo.toml`