### PR TITLE
ci: disable checkout credential persistence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
(opened by mistake; I wrote a script which didn't filter forks out, sorry)