### PR TITLE
webpki-ccadb: add V5 certificate records

### DIFF
--- a/webpki-ccadb/README.md
+++ b/webpki-ccadb/README.md
@@ -1,6 +1,7 @@
 # webpki-ccadb
-This is a crate to fetch Mozilla's root certificates for use with
-[webpki-roots](https://github.com/rustls/webpki-roots) crate.
+This is a crate to fetch Mozilla's root certificates for use with the
+[webpki-roots](https://github.com/rustls/webpki-roots) crate, and certificate records from the
+CCADB All Certificate Records V5 report.
 
 This crate is inspired by [certifi.io](https://certifi.io/en/latest/) and
 uses the data provided by the [Common CA Database (CCADB)](https://www.ccadb.org/).

--- a/webpki-ccadb/src/lib.rs
+++ b/webpki-ccadb/src/lib.rs
@@ -8,11 +8,7 @@ use pki_types::pem::PemObject;
 use pki_types::CertificateDer;
 use serde::Deserialize;
 
-// Fetch root certificate data from the CCADB server.
-//
-// Returns an ordered BTreeMap of the root certificates, keyed by the SHA256 fingerprint of the
-// certificate. Panics if there are any duplicate fingerprints.
-pub async fn fetch_ccadb_roots() -> BTreeMap<String, CertificateMetadata> {
+fn ccadb_client() -> reqwest::Client {
     // Configure a Reqwest client that only trusts the CA certificate expected to be the
     // root of trust for the CCADB server.
     //
@@ -30,11 +26,19 @@ pub async fn fetch_ccadb_roots() -> BTreeMap<String, CertificateMetadata> {
     //  8. Committing the updated .pem root CA, and updating the `include_bytes!` path.
     let root = include_bytes!("data/DigiCertGlobalRootG2.pem");
     let root = reqwest::Certificate::from_pem(root).unwrap();
-    let client = reqwest::Client::builder()
+    reqwest::Client::builder()
         .user_agent(format!("webpki-ccadb/v{}", env!("CARGO_PKG_VERSION")))
         .tls_certs_only([root])
         .build()
-        .unwrap();
+        .unwrap()
+}
+
+// Fetch root certificate data from the CCADB server.
+//
+// Returns an ordered BTreeMap of the root certificates, keyed by the SHA256 fingerprint of the
+// certificate. Panics if there are any duplicate fingerprints.
+pub async fn fetch_ccadb_roots() -> BTreeMap<String, CertificateMetadata> {
+    let client = ccadb_client();
 
     let ccadb_url =
         "https://ccadb.my.salesforce-sites.com/mozilla/IncludedCACertificateReportPEMCSV";
@@ -77,6 +81,81 @@ pub async fn fetch_ccadb_roots() -> BTreeMap<String, CertificateMetadata> {
     }
 
     tls_roots_map
+}
+
+/// Fetches certificate records from the CCADB All Certificate Records V5 report.
+///
+/// Records are returned in report order. The report can contain more than one record with the
+/// same certificate fingerprint, so the result is not keyed by fingerprint.
+pub async fn fetch_ccadb_certificate_records() -> Vec<CertificateRecord> {
+    let client = ccadb_client();
+    let ccadb_url = "https://ccadb.my.salesforce-sites.com/ccadb/AllCertificateRecordsCSVFormatV5";
+    eprintln!("fetching {ccadb_url}...");
+
+    let req = client.get(ccadb_url).build().unwrap();
+    let csv_data = client
+        .execute(req)
+        .await
+        .expect("failed to fetch CSV")
+        .text()
+        .await
+        .unwrap();
+
+    parse_certificate_records(csv_data.as_bytes())
+}
+
+fn parse_certificate_records(csv_data: &[u8]) -> Vec<CertificateRecord> {
+    csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(csv_data)
+        .into_deserialize::<CertificateRecord>()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+/// A certificate record from the CCADB All Certificate Records V5 report.
+#[non_exhaustive]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
+pub struct CertificateRecord {
+    /// The unique identifier assigned to this certificate record by CCADB.
+    ///
+    /// See the [CCADB field descriptions] for details.
+    ///
+    /// [CCADB field descriptions]: https://docs.google.com/document/d/1S3u0-_YACA7m-3LPpjE-t4WCh2cww_SQFh2C9DJeXHA/edit?usp=sharing
+    #[serde(rename = "Salesforce Record ID")]
+    pub salesforce_record_id: String,
+
+    /// The certificate name in CCADB.
+    #[serde(rename = "Certificate Name")]
+    pub certificate_name: String,
+
+    /// The SHA-256 fingerprint of the certificate represented by this record.
+    #[serde(rename = "SHA-256 Fingerprint")]
+    pub certificate_sha256_fingerprint: String,
+
+    #[serde(rename = "Certificate Record Type")]
+    pub certificate_record_type: String,
+
+    #[serde(rename = "Chrome Status")]
+    pub chrome_status: String,
+
+    #[serde(rename = "Revocation Status")]
+    pub revocation_status: String,
+
+    #[serde(rename = "Technically Constrained")]
+    pub technically_constrained: String,
+
+    #[serde(rename = "Derived Trust Bits")]
+    pub derived_trust_bits: String,
+
+    #[serde(rename = "TLS Capable")]
+    pub tls_capable: String,
+
+    #[serde(rename = "JSON Array of All Full CRL URLs")]
+    pub json_array_of_all_full_crl_urls: String,
+
+    #[serde(rename = "JSON Array of Partitioned CRLs")]
+    pub json_array_of_partitioned_crls: String,
 }
 
 #[non_exhaustive]
@@ -292,6 +371,71 @@ static EXCLUDED_FINGERPRINTS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn certificate_records_preserve_selected_fields_and_duplicate_fingerprints() {
+        let mut csv = csv::Writer::from_writer(Vec::new());
+        csv.write_record([
+            "Salesforce Record ID",
+            "Certificate Name",
+            "SHA-256 Fingerprint",
+            "Certificate Record Type",
+            "Chrome Status",
+            "Revocation Status",
+            "Technically Constrained",
+            "Derived Trust Bits",
+            "TLS Capable",
+            "JSON Array of All Full CRL URLs",
+            "JSON Array of Partitioned CRLs",
+        ])
+        .unwrap();
+        csv.write_record([
+            "a0A1",
+            "First certificate",
+            "AA",
+            "Root Certificate",
+            "Included",
+            "Not Revoked",
+            "No",
+            "Server Authentication",
+            "true",
+            r#"["https://example.com/root.crl"]"#,
+            "[]",
+        ])
+        .unwrap();
+        csv.write_record([
+            "a0A2",
+            "Second certificate",
+            "AA",
+            "Intermediate Certificate",
+            "",
+            "Not Revoked",
+            "Yes",
+            "",
+            "false",
+            "[]",
+            r#"[{"Partition":"https://example.com/partition.crl"}]"#,
+        ])
+        .unwrap();
+
+        let records = parse_certificate_records(&csv.into_inner().unwrap());
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].salesforce_record_id, "a0A1");
+        assert_eq!(records[0].certificate_name, "First certificate");
+        assert_eq!(records[0].certificate_sha256_fingerprint, "AA");
+        assert_eq!(
+            records[0].json_array_of_all_full_crl_urls,
+            r#"["https://example.com/root.crl"]"#
+        );
+        assert_eq!(records[1].salesforce_record_id, "a0A2");
+        assert_eq!(records[1].certificate_name, "Second certificate");
+        assert_eq!(records[1].certificate_sha256_fingerprint, "AA");
+        assert_eq!(
+            records[1].json_array_of_partitioned_crls,
+            r#"[{"Partition":"https://example.com/partition.crl"}]"#
+        );
+    }
 
     #[test]
     fn test_trusted_for_tls() {


### PR DESCRIPTION
The first thing necessary in order to make `rustls-platform-verifier` use this crate in order to build a list of all CRLs
This uses https://www.ccadb.org/resources "All Certificate Information Reports" V5.
It cannot be merged with the existing endpoint as they return different things where the V5 endpoint can return "duplicate" certificate fingerprints(e.g. one for a root cert and one for an intermediate cert), e.g.:
```
"Asseco Data Systems S.A.","A010457","Certum Trusted Network CA 2","A000061","Asseco Data Systems S.A.","Root Certificate","","Not Included","Not Included","Removed","Not Yet Included","Apple: Not Included; Google Chrome: Not Included; Microsoft: Removed; Mozilla: Not Yet Included","","9F8B05137F20ACDE9B996410F4D0BF7971A1006DC99E094C346D279B93CFF7AE","","2011.10.06","2046.10.06","","tqFUOQLDoD+Oirz61PgcptE6Dv0=","false","","","","","","","","","","Ernst & Young, LLP","Poland","false","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=84a61b66-db2a-4a62-a227-ea3624e52f3e","WebTrust","2026.04.27","2025.02.11","2026.02.10","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=55c7a16e-283a-4bf2-8e88-3f716fff5cea","WebTrust","2026.04.03","2025.02.11","2026.02.10","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=a23fcf5d-bdb5-45d3-abbb-2b230214f989","WebTrust","2026.04.03","2025.02.11","2026.02.10","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=7799eaad-dd3c-489b-9dd1-21c5c1c6046c","WebTrust","2026.04.03","2025.02.11","2026.02.10","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=c175793c-60ed-4c70-8bf7-f875050e202a","WebTrust","2026.04.03","2025.02.11","2026.02.10","https://www.cpacanada.ca/api/getPDFWebTrust?attachmentId=5071ae66-985b-4eba-81c0-ee2df7f0a57b","WebTrust","2026.04.03","2025.02.11","2026.02.10","","","","","","","https://www.certum.pl/pl/cert_wiedza_repozytorium_pl_en/","false","https://www.certum.eu/en/wp-content/uploads/2025/11/Certification-Policy-of-Certum-Certification-Services_v5.2.pdf","2025.12.01","false","https://www.certum.eu/en/wp-content/uploads/2026/05/Certification-Practice-Statement-of-Certum-Certification-Services_v8.4.pdf","2026.06.01","false","https://repository.certum.pl/cp-cps-tls/certum-cp-cps-tls-certificates-en-1-0-1.pdf","2026.07.20","false","","","","","","False","True","False","False","Polska"
"Asseco Data Systems S.A.","A003934","Certum Trusted Network CA 2","A000815","Certum Trusted Network CA 2","Intermediate Certificate","","Not Trusted","Not Trusted","Not Trusted","Not Trusted","Apple: Included; Google Chrome: Included; Microsoft: Included; Mozilla: Included","Revoked","9F8B05137F20ACDE9B996410F4D0BF7971A1006DC99E094C346D279B93CFF7AE","B676F2EDDAE8775CD36CB0F63CD1D4603961F49E6265BA013A2F0307B6D0B804","2011.10.06","2046.10.06","","tqFUOQLDoD+Oirz61PgcptE6Dv0=","false","","","","[""http://crl.certum.pl/ctnca2.crl""]","","","","","","","","true","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","","true","","","true","","","false","","","false","","","","","","False","False","False","False","Polska"
```

The plan is to use this in `rustls-platform-verifier` tests in order to keep an up-to-date CRL list.
Based on: https://github.com/rustls/rustls-platform-verifier/issues/221#issuecomment-5194809290

I will create a follow-up PR in `rustls-platform-verifier` in the following days, showing how this is used
